### PR TITLE
Replacing filemanager2

### DIFF
--- a/PLUGINS_TO_STABLE.md
+++ b/PLUGINS_TO_STABLE.md
@@ -3,3 +3,4 @@
 Put the name of the plugin as a list item here, So like
 - filemanager2
 -->
+- filemanager2

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ All the plugins are located externally with the latest update and is possible to
 [colorschemes]: https://codeberg.org/micro-plugins/colorschemes
 [delve]: https://github.com/serge-v/micro-delve
 [emacs_select]: https://github.com/kesslern/micro-emacs-select
-[filemanager2]: https://codeberg.org/micro-plugins/filemanager2
+[filemanager2]: https://github.com/Neko-Box-Coder/filemanager2
 [findinfolder]: https://codeberg.org/micro-plugins/findinfolder
 [fzfinder]: https://github.com/MuratovAS/micro-fzfinder
 [gitStatus]: https://codeberg.org/micro-plugins/git-status

--- a/channel.json
+++ b/channel.json
@@ -22,7 +22,7 @@
     //emacs_select
     "https://raw.githubusercontent.com/kesslern/micro-emacs-select/main/repo.json",
     //filemanager2
-    "https://codeberg.org/micro-plugins/filemanager2/raw/branch/main/repo.json",
+    "https://raw.githubusercontent.com/Neko-Box-Coder/filemanager2/main/repo.json",
     //findinfolder
     "https://codeberg.org/micro-plugins/findinfolder/raw/branch/main/repo.json",
     //fzfinder

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -12,6 +12,7 @@ Checklist:
 
 - [ ] Create a PR to `main`
 - [ ] Modify `README.md` and add an entry to the plugin (The name **MUST** match the `repo.json`). Remember it is in alphabatical order.
+<--! Please add ❓️ icon in the code check column, I will check the code and update it when adding it to stable channel -->
 - [ ] Modify `channel.json` to point to `repo.json` in the plugin repo. Remember it is in alphabatical order.
 - [ ] Modify `PLUGINS_TO_STABLE.md` and add the name of the plugin
 


### PR DESCRIPTION
This is a

- [ ] New plugin.
- [x] Update to an existing plugin.

Plugin name: filemanager2
Plugin Repository: https://github.com/Neko-Box-Coder/filemanager2

Checklist:

## ➕ Adding a plugin

- [ ] Create a PR to `main`
- [ ] Modify `README.md` and add an entry to the plugin (The name **MUST** match the `repo.json`). Remember it is in alphabatical order.
- [ ] Modify `channel.json` to point to `repo.json` in the plugin repo. Remember it is in alphabatical order.
- [ ] Modify `PLUGINS_TO_STABLE.md` and add the name of the plugin

## 🔼 Updating a plugin for both main and stable
- [x] Create a PR to `main`
- [x] Modify `README.md` for the plugin if needed
- [x] Modify `channel.json` if `repo.json` is in a different url
- [x] Modify `PLUGINS_TO_STABLE.md` and add the name of the plugin
- [x] If there's any change needed to be made to `stable`, specify in PR.

---

<!-- Other comments here -->
