### PR TITLE
Add uchardet plugin

### DIFF
--- a/PLUGINS_TO_STABLE.md
+++ b/PLUGINS_TO_STABLE.md
@@ -3,3 +3,4 @@
 Put the name of the plugin as a list item here, So like
 - filemanager2
 -->
+- uchardet

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ All the plugins are located externally with the latest update and is possible to
 | ✅ | [acme] | An acme style editing plugin for the micro editor. | ![Linux] ![macOS] | |
 | ✅ | [align] | Simple plugin to align multiple cursors in micro. | ![Linux] ![macOS] ![Windows] | |
 | ✅ | [ag] | This plugin provides the ability to search with "ag" (aka the_silver_searcher). | ![Linux] ![macOS] ![Windows] | [ag_] |
-| ✅ | [aspell] | Spellchecking with Aspel. | ![Linux] ![macOS] ![Windows] | [aspell_] |
+| ✅ | [aspell] | Spellchecking with Aspell. | ![Linux] ![macOS] ![Windows] | [aspell_] |
 | ✅ | [battery] | Shows battery percentage on infobar. | ![Linux] | |
 | ✅ | [calc] | Add calc command for calculating math. | ![Linux] | [calc_] |
 | ✅ | [capitalizer] | A simple micro-editor plugin that allows to capitalize selected text. | ![Linux] ![macOS] ![Windows] | |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ All the plugins in this channel are located in this repo and checked to not cont
 
 ```json
 "pluginchannels": [
-    https://raw.githubusercontent.com/Neko-Box-Coder/unofficial-plugin-channel/stable/channel.json
+    "https://raw.githubusercontent.com/Neko-Box-Coder/unofficial-plugin-channel/stable/channel.json"
 ]
 ```
 
@@ -41,7 +41,7 @@ All the plugins are located externally with the latest update and is possible to
 
 ```json
 "pluginchannels": [
-    https://raw.githubusercontent.com/Neko-Box-Coder/unofficial-plugin-channel/main/channel.json
+    "https://raw.githubusercontent.com/Neko-Box-Coder/unofficial-plugin-channel/main/channel.json"
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ All the plugins are located externally with the latest update and is possible to
 | ✅ | [sunny-day-theme] | Port of the Emacs theme by Martin Haesler. | ![Linux] ![Windows] ![macOS] | |
 | ✅ | [testaustime] | Testaustime coding activity tracker for micro. | ![Linux] ![macOS] | |
 | ✅ | [transform] | Plugin to do various kind of text transformations in Micro. | ![Linux] ![Windows] ![macOS] | |
+| ❓️ | [uchardet] | Encoding detection. | ![Linux] ![Windows] ![macOS] | [uchardet_] |
 | ✅ | [urlopen] | A plugin for the micro text editor to add support for opening URLs in text files. | ![macOS] | |
 | ✅ | [wakatime] | Metrics, insights, and time tracking automatically generated from your programming activity. | ![Linux] ![Windows] ![macOS] | |
 | ✅ | [xonsh] | Syntax highlighting for xonsh files. | ![Linux] ![Windows] ![macOS] | |
@@ -151,6 +152,7 @@ All the plugins are located externally with the latest update and is possible to
 [sunny-day-theme]: https://github.com/dwwmmn/micro-sunny-day
 [testaustime]: https://github.com/testaustime/testaustime-micro
 [transform]: https://github.com/SuSonicTH/micro-transform
+[uchardet]: https://github.com/niten94/micro-uchardet
 [urlopen]: https://github.com/pjg11/micro-urlopen
 [wakatime]: https://github.com/wakatime/micro-wakatime
 [xonsh]: https://codeberg.org/micro-plugins/xonsh
@@ -184,4 +186,5 @@ All the plugins are located externally with the latest update and is possible to
 [prettier_]: https://github.com/prettier/prettier
 [pandoc]: https://github.com/jgm/pandoc
 [firefox-esr]: https://www.mozilla.org/en-US/firefox/
+[uchardet_]: https://www.freedesktop.org/wiki/Software/uchardet/
 

--- a/channel.json
+++ b/channel.json
@@ -79,6 +79,8 @@
     "https://raw.githubusercontent.com/SuSonicTH/micro-transform/master/repo.json",
     //transform
     "https://raw.githubusercontent.com/Testaustime/testaustime-micro/master/repo.json",
+    //uchardet
+    "https://raw.githubusercontent.com/niten94/micro-uchardet/master/repo.json",
     //urlopen
     "https://raw.githubusercontent.com/pjg11/micro-urlopen/main/repo.json",
     //wakatime


### PR DESCRIPTION
This is a

- [x] New plugin.
- [ ] Update to an existing plugin.

Plugin name: uchardet
Plugin Repository: https://github.com/niten94/micro-uchardet

Checklist:

## ➕ Adding a plugin

- [x] Create a PR to `main`
- [x] Modify `README.md` and add an entry to the plugin (The name **MUST** match the `repo.json`). Remember it is in alphabatical order.
- [x] Modify `channel.json` to point to `repo.json` in the plugin repo. Remember it is in alphabatical order.
- [x] Modify `PLUGINS_TO_STABLE.md` and add the name of the plugin

## 🔼 Updating a plugin for both main and stable
- [ ] Create a PR to `main`
- [ ] Modify `README.md` for the plugin if needed
- [ ] Modify `channel.json` if `repo.json` is in a different url
- [ ] Modify `PLUGINS_TO_STABLE.md` and add the name of the plugin
- [ ] If there's any change needed to be made to `stable`, specify in PR.

---

<!-- Other comments here -->

The plugin provides a command where the encoding of the file currently opened is detected and the file is reopened in the encoding that was detected. Please note that the command line tool is used but there is no download links or instructions of the tool in the page at the link in the requirements of the plugin. There are package repositories where the tool and the library is in one package.

There was a typo in the description of the aspell plugin in `README.md` so it is fixed in this pull request. It may be thought that quotes do not have to be inserted in `settings.json` when adding plugin channels, so they are inserted too.