### PR TITLE
Update Windows Icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,14 @@ All the plugins are located externally with the latest update and is possible to
 <!--[Linux]: https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black
 [macOS]: https://img.shields.io/badge/mac%20os-000000?style=for-the-badge&logo=macos&logoColor=F0F0F0
 [Windows]: https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white -->
+
 [Linux]: https://img.shields.io/badge/--FCC624?logo=linux&logoColor=000000
-[Windows]: https://img.shields.io/badge/--08a1f7?logo=windows&logoColor=ffffff
+
+<!-- It seems like the windows icon is being take down for copyright review -->
+<!-- See https://github.com/simple-icons/simple-icons/pull/10019 -->
+<!-- [Windows]: https://img.shields.io/badge/--08a1f7?logo=windows&logoColor=ffffff -->
+[Windows]: https://badgen.net/badge/_/Win10?icon=windows&label
+
 [macOS]: https://img.shields.io/badge/--181717?logo=apple
 
 [ag_]: https://github.com/ggreer/the_silver_searcher

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,17 +2,18 @@ This is a
 
 - [ ] New plugin.
 - [ ] Update to an existing plugin.
+- [ ] Fix to an issue
 
 Plugin name:
 Plugin Repository:
 
-Checklist:
+## Checklist:
 
 ## ➕ Adding a plugin
 
 - [ ] Create a PR to `main`
 - [ ] Modify `README.md` and add an entry to the plugin (The name **MUST** match the `repo.json`). Remember it is in alphabatical order.
-<--! Please add ❓️ icon in the code check column, I will check the code and update it when adding it to stable channel -->
+<!-- Please add ❓️ icon in the code check column, I will check the code and update it when adding it to stable channel -->
 - [ ] Modify `channel.json` to point to `repo.json` in the plugin repo. Remember it is in alphabatical order.
 - [ ] Modify `PLUGINS_TO_STABLE.md` and add the name of the plugin
 
@@ -21,8 +22,11 @@ Checklist:
 - [ ] Modify `README.md` for the plugin if needed
 - [ ] Modify `channel.json` if `repo.json` is in a different url
 - [ ] Modify `PLUGINS_TO_STABLE.md` and add the name of the plugin
-- [ ] If there's any change needed to be made to `stable`, specify in PR.
+- [ ] If there's any change needed to be made to `stable`, specify in the description below.
+
+## 🔧 Fix to an issue
+- [ ] Specify the fix in the description below.
 
 ---
 
-<!-- Other comments here -->
+<!-- Comments or description goes here -->


### PR DESCRIPTION
This is a

- [ ] New plugin.
- [ ] Update to an existing plugin.
- [x] Fixing issues

Plugin name:
Plugin Repository:

Checklist:

## ➕ Adding a plugin

- [ ] Create a PR to `main`
- [ ] Modify `README.md` and add an entry to the plugin (The name **MUST** match the `repo.json`). Remember it is in alphabatical order.
<--! Please add ❓️ icon in the code check column, I will check the code and update it when adding it to stable channel -->
- [ ] Modify `channel.json` to point to `repo.json` in the plugin repo. Remember it is in alphabatical order.
- [ ] Modify `PLUGINS_TO_STABLE.md` and add the name of the plugin

## 🔼 Updating a plugin for both main and stable
- [ ] Create a PR to `main`
- [ ] Modify `README.md` for the plugin if needed
- [ ] Modify `channel.json` if `repo.json` is in a different url
- [ ] Modify `PLUGINS_TO_STABLE.md` and add the name of the plugin
- [ ] If there's any change needed to be made to `stable`, specify in PR.

---

<!-- Other comments here -->

The Windows badge icon is being removed, due to https://github.com/simple-icons/simple-icons/pull/10019
A replacement from badgen is used for the time being until there's a replacement from simple icons


