### PR TITLE
add llm plugin to unofficial-plugin-channel

### DIFF
--- a/PLUGINS_TO_STABLE.md
+++ b/PLUGINS_TO_STABLE.md
@@ -4,3 +4,4 @@ Put the name of the plugin as a list item here, So like
 - filemanager2
 -->
 - gitStatus
+- llm

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ All the plugins are located externally with the latest update and is possible to
 | ✅ | [language_log] | Syntax highlighting for files with .log extension. | ![Linux] ![Windows] ![macOS] | |
 | ✅ | [latexplugin] | Latex plugin for Micro editor. Main aim is to provide synctex support. | ![Linux] ![macOS] | [pdflatex], [python] |
 | ✅ | [lintertypescript] | Ability to lint your Typescript (.ts & .tsx) files with tsc. | ![Linux] ![Windows] ![macOS] | [typescript] |
+| ❓️ | [llm] | Integrates Simon Willison's LLM CLI with the Micro editor. This plugin allows you to leverage Large Language Models directly within Micro for text generation, modification, and custom-defined tasks through templates. | ![Linux] ![Windows] ![macOS] |[llm_] |
 | ❓️ | [manager] | Provides a way to manage linters, formatters, commands, keybindings, settings, plugins. | ![Linux] ![macOS] | [fzf], unknown... |
 | ✅ | [mdtree] | A plugin for the micro text editor to add sidebar for jumpring and viewing TOC of markdown files. | ![Linux] ![Windows] ![macOS] | |
 | ✅ | [MicroOmni] | A swiss army knife plugin that super charges ⚡️ your micro text editor with fuzzy search, diffs, etc. | ![Linux] ![Windows] ![macOS] | [fzf], [bat], [ripgrep], [diff on windows] |
@@ -141,6 +142,7 @@ All the plugins are located externally with the latest update and is possible to
 [language_log]: https://codeberg.org/micro-plugins/language-log
 [latexplugin]: https://github.com/chykcha3/micro-plugin-latex
 [lintertypescript]: https://github.com/sebkolind/micro-linter-typescript
+[llm]: https://github.com/shamanicvocalarts/llm-micro
 [manager]: https://codeberg.org/micro-plugins/manager
 [mdtree]: https://notabug.org/dustdfg/micro-mdtree
 [MicroOmni]: https://github.com/Neko-Box-Coder/MicroOmni
@@ -195,6 +197,7 @@ All the plugins are located externally with the latest update and is possible to
 [git]: https://git-scm.com/
 [grep on windows]: https://github.com/mbuilov/grep-windows
 [imagemagick]: https://github.com/ImageMagick/ImageMagick
+[llm_]: https://github.com/simonw/llm 
 [nelua_]: https://nelua.io/
 [nix_]: https://nixos.org/
 [nnn]: https://github.com/jarun/nnn
@@ -206,4 +209,5 @@ All the plugins are located externally with the latest update and is possible to
 [ripgrep]: https://github.com/BurntSushi/ripgrep
 [typescript]: https://www.typescriptlang.org/download/
 [uchardet_]: https://www.freedesktop.org/wiki/Software/uchardet/
+
 

--- a/channel.json
+++ b/channel.json
@@ -49,6 +49,8 @@
     "https://raw.githubusercontent.com/chykcha3/micro-plugin-latex/main/repo.json",
     //lintertypescript
     "https://raw.githubusercontent.com/sebkolind/micro-linter-typescript/master/repo.json",
+    //llm
+    "https://raw.githubusercontent.com/shamanicvocalarts/llm-micro/refs/heads/main/repo.json",
     //manager
     "https://codeberg.org/micro-plugins/manager/raw/branch/main/repo.json",
     //mdtree


### PR DESCRIPTION
This is a

- [x] New plugin.
- [ ] Update to an existing plugin.
- [ ] Fix to an issue

Plugin name: llm 
Plugin Repository: https://github.com/shamanicvocalarts/llm-micro

## Checklist:

## ➕ Adding a plugin

- [x] Create a PR to `main`
- [x] Modify `README.md` and add an entry to the plugin (The name **MUST** match the `repo.json`). Remember it is in alphabatical order.
<!-- Please add ❓️ icon in the code check column, I will check the code and update it when adding it to stable channel -->
- [x] Modify `channel.json` to point to `repo.json` in the plugin repo. Remember it is in alphabatical order.
- [x] Modify `PLUGINS_TO_STABLE.md` and add the name of the plugin

## 🔼 Updating a plugin for both main and stable
- [ ] Create a PR to `main`
- [ ] Modify `README.md` for the plugin if needed
- [ ] Modify `channel.json` if `repo.json` is in a different url
- [ ] Modify `PLUGINS_TO_STABLE.md` and add the name of the plugin
- [ ] If there's any change needed to be made to `stable`, specify in the description below.

## 🔧 Fix to an issue
- [ ] Specify the fix in the description below.

---

<!-- Comments or description goes here -->


llm is a cli tool from simonw, this plugin integrates the llm cli with the micro text editor allowing the user to modify or generate text in micro 