### PR TITLE
Add markdown-autocomplete

### DIFF
--- a/PLUGINS_TO_STABLE.md
+++ b/PLUGINS_TO_STABLE.md
@@ -13,6 +13,7 @@ Put the name of the plugin as a list item here, So like
 - gutter_message
 - latexplugin
 - MicroOmni
+- Markdown_Autocomplete
 - mxc
 - repfiles
 - runit

--- a/PLUGINS_TO_STABLE.md
+++ b/PLUGINS_TO_STABLE.md
@@ -13,7 +13,7 @@ Put the name of the plugin as a list item here, So like
 - gutter_message
 - latexplugin
 - MicroOmni
-- Markdown_Autocomplete
+- markdown_autocomplete
 - mxc
 - repfiles
 - runit

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ For example,
 | ✅ | [latexplugin] (Yes) | Latex plugin for Micro editor. Main aim is to provide synctex support. | ![Linux] ![macOS] | [pdflatex], [python] |
 | ✅ | [lintertypescript] (Yes) | Ability to lint your Typescript (.ts & .tsx) files with tsc. | ![Linux] ![Windows] ![macOS] | [typescript] |
 | ❓️ | [llm] (Yes) | Integrates Simon Willison's LLM CLI with the Micro editor. This plugin allows you to leverage Large Language Models directly within Micro for text generation, modification, and custom-defined tasks through templates. | ![Linux] ![Windows] ![macOS] |[llm_] |
+| ✅ | [markdown-autocomplete](https://github.com/dalekirkwood/markdown-autocomplete) (Yes) | Basic Autocomplete for Markdown files. | Linux Windows macOS |
 | ❓️ | [manager] <br> (No, upstream gone) | Provides a way to manage linters, formatters, commands, keybindings, settings, plugins. | ![Linux] ![macOS] | [fzf], unknown... |
 | ✅ | [mdtree] (Yes) | A plugin for the micro text editor to add sidebar for jumpring and viewing TOC of markdown files. | ![Linux] ![Windows] ![macOS] | |
 | ✅ | [MicroOmni] (Yes) | A swiss army knife plugin that super charges ⚡️ your micro text editor with fuzzy search, diffs, etc. | ![Linux] ![Windows] ![macOS] | [fzf], [bat], [ripgrep], [diff on windows] |

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ For example,
 [latexplugin]: https://github.com/chykcha3/micro-plugin-latex
 [lintertypescript]: https://github.com/sebkolind/micro-linter-typescript
 [llm]: https://github.com/shamanicvocalarts/llm-micro
-[markdown-autocomplete]: https://github.com/dalekirkwood/markdown-autocomplete
+[markdown_autocomplete]: https://github.com/dalekirkwood/markdown-autocomplete
 [manager]: https://codeberg.org/micro-plugins/manager
 [mdtree]: https://notabug.org/dustdfg/micro-mdtree
 [MicroOmni]: https://github.com/Neko-Box-Coder/MicroOmni

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ For example,
 | ✅ | [latexplugin] (Yes) | Latex plugin for Micro editor. Main aim is to provide synctex support. | ![Linux] ![macOS] | [pdflatex], [python] |
 | ✅ | [lintertypescript] (Yes) | Ability to lint your Typescript (.ts & .tsx) files with tsc. | ![Linux] ![Windows] ![macOS] | [typescript] |
 | ❓️ | [llm] (Yes) | Integrates Simon Willison's LLM CLI with the Micro editor. This plugin allows you to leverage Large Language Models directly within Micro for text generation, modification, and custom-defined tasks through templates. | ![Linux] ![Windows] ![macOS] |[llm_] |
-| ❓| [markdown-autocomplete] (Yes) | Basic Autocomplete for Markdown files. | Linux Windows macOS |
+| ❓| [markdown_autocomplete] (Yes) | Basic Autocomplete for Markdown files. | Linux Windows macOS |
 | ❓️ | [manager] <br> (No, upstream gone) | Provides a way to manage linters, formatters, commands, keybindings, settings, plugins. | ![Linux] ![macOS] | [fzf], unknown... |
 | ✅ | [mdtree] (Yes) | A plugin for the micro text editor to add sidebar for jumpring and viewing TOC of markdown files. | ![Linux] ![Windows] ![macOS] | |
 | ✅ | [MicroOmni] (Yes) | A swiss army knife plugin that super charges ⚡️ your micro text editor with fuzzy search, diffs, etc. | ![Linux] ![Windows] ![macOS] | [fzf], [bat], [ripgrep], [diff on windows] |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ For example,
 | ✅ | [latexplugin] (Yes) | Latex plugin for Micro editor. Main aim is to provide synctex support. | ![Linux] ![macOS] | [pdflatex], [python] |
 | ✅ | [lintertypescript] (Yes) | Ability to lint your Typescript (.ts & .tsx) files with tsc. | ![Linux] ![Windows] ![macOS] | [typescript] |
 | ❓️ | [llm] (Yes) | Integrates Simon Willison's LLM CLI with the Micro editor. This plugin allows you to leverage Large Language Models directly within Micro for text generation, modification, and custom-defined tasks through templates. | ![Linux] ![Windows] ![macOS] |[llm_] |
-| ✅ | [markdown-autocomplete](https://github.com/dalekirkwood/markdown-autocomplete) (Yes) | Basic Autocomplete for Markdown files. | Linux Windows macOS |
+| ❓| [markdown-autocomplete] (Yes) | Basic Autocomplete for Markdown files. | Linux Windows macOS |
 | ❓️ | [manager] <br> (No, upstream gone) | Provides a way to manage linters, formatters, commands, keybindings, settings, plugins. | ![Linux] ![macOS] | [fzf], unknown... |
 | ✅ | [mdtree] (Yes) | A plugin for the micro text editor to add sidebar for jumpring and viewing TOC of markdown files. | ![Linux] ![Windows] ![macOS] | |
 | ✅ | [MicroOmni] (Yes) | A swiss army knife plugin that super charges ⚡️ your micro text editor with fuzzy search, diffs, etc. | ![Linux] ![Windows] ![macOS] | [fzf], [bat], [ripgrep], [diff on windows] |
@@ -151,6 +151,7 @@ For example,
 [latexplugin]: https://github.com/chykcha3/micro-plugin-latex
 [lintertypescript]: https://github.com/sebkolind/micro-linter-typescript
 [llm]: https://github.com/shamanicvocalarts/llm-micro
+[markdown-autocomplete]: https://github.com/dalekirkwood/markdown-autocomplete
 [manager]: https://codeberg.org/micro-plugins/manager
 [mdtree]: https://notabug.org/dustdfg/micro-mdtree
 [MicroOmni]: https://github.com/Neko-Box-Coder/MicroOmni

--- a/channel.json
+++ b/channel.json
@@ -55,6 +55,8 @@
     "https://raw.githubusercontent.com/shamanicvocalarts/llm-micro/refs/heads/main/repo.json",
     //manager
     "https://raw.githubusercontent.com/Neko-Box-Coder/unofficial-plugin-channel/main/plugins/manager.json",
+    //markdown_autocomplete
+    "https://raw.githubusercontent.com/dalekirkwood/markdown-autocomplete/main/repo.json",
     //mdtree
     "https://notabug.org/dustdfg/micro-mdtree/raw/master/repo.json",
     //MicroOmni


### PR DESCRIPTION
Basic autocomplete tool for Markdown. Includes a demo GIF in the repo.